### PR TITLE
Feat/api sns 최적화 + 웹소켓 연결

### DIFF
--- a/src/pages/login/LoginSuccess.jsx
+++ b/src/pages/login/LoginSuccess.jsx
@@ -24,8 +24,9 @@ function LoginSuccess() {
         }
 
         const data = await response.json();
+        console.log(data);
 
-        Cookies.set("userEmail", data.email, { path: '/' });
+        Cookies.set("userEmail", data.userId, { path: '/' });
 
         navigate("/");
       } catch (error) {

--- a/src/pages/sns/ChatApiService.js
+++ b/src/pages/sns/ChatApiService.js
@@ -27,6 +27,16 @@ export const getChatRoomById = (roomId) => {
     });
 };
 
+// 특정 채팅방의 모든 메시지 가져오기
+export const getChatRoomMessagesById = (roomId) => {
+  return api.get(`/messenger/chatRoom/${roomId}/messages`)
+    .then(response => response.data)
+    .catch(error => {
+      console.error("Error getting chat room messages:", error);
+      throw error;
+    });
+};
+
 // 특정 채팅방에 사용자 초대
 export const inviteUserToChatRoom = (roomId, inviteUserId) => {
   return api.post(`/messenger/chatRoom/${roomId}`, { inviteUserId });

--- a/src/pages/sns/ChatWindow.jsx
+++ b/src/pages/sns/ChatWindow.jsx
@@ -104,13 +104,8 @@ function ChatWindow({ selectedChat, onSendMessage }) {
         headers: { Authorization: `Bearer ${Cookies.get('access')}` }
       });
 
-      setChatHistories(prevHistories => ({
-        ...prevHistories,
-        [selectedChat.id]: [...(prevHistories[selectedChat.id] || []), newChat]
-      }));
-      onSendMessage(message);
+      // onSendMessage(message); 이 부분을 제거하여 메시지를 즉시 목록에 추가하지 않음
       setMessage("");
-      scrollToBottom();
     }
   };
 


### PR DESCRIPTION
#  sns 최적화 + 웹소켓 연결 
> 구현한 기능: 웹소켓 연결하여 실시간 통신 가능하도록 설정

프론트만 고친 게 아니라 백엔드도 같이 수정했습니다!

- [x] 사용자가 로그인한 이메일 주소로 메시지가 보내지도록 설정
- [x] 특정채팅방의 모든 메시지를 불러오는 api 추가
- [x] api 호출하여 ChatHistories 상태에 저장시키고, UI에 반영되도록 설정
- [x] selectChat이 변경될 때마다 함수 호출하여 채팅방 메시지 가져오도록 설정

# 실행화면
### 새로운 채팅방 생성
> name: 보라카이
<img width="1345" alt="스크린샷 2024-06-06 오후 10 08 53" src="https://github.com/24AWP-FAVICON/frontend/assets/101111603/89e8fd42-3b26-464b-b89c-8a0e001d17b6">

### 사용자 초대
> 현재 사용자: minbory925@gmail.com
다른 사용자 초대: deepdevming@gmail.com
<img width="1345" alt="스크린샷 2024-06-06 오후 10 09 04" src="https://github.com/24AWP-FAVICON/frontend/assets/101111603/2acaf35c-8f88-48e3-a8a7-4d093fa798cc">

초대된 사용자의 화면에서 잘 초대되었는지 확인
<img width="1371" alt="스크린샷 2024-06-06 오후 10 09 13" src="https://github.com/24AWP-FAVICON/frontend/assets/101111603/196944cc-260e-44ee-9d36-5d7bb05ea86d">


### 실시간 통신 연결 확인
<img width="1710" alt="스크린샷 2024-06-06 오후 10 09 45" src="https://github.com/24AWP-FAVICON/frontend/assets/101111603/96954833-dbd7-485c-950c-d8e04fede3e0">


### 데이터베이스에 잘 저장되었는지 확인 
> `roomId`가 `81`인 채팅방 대화 내역 조회
<img width="596" alt="스크린샷 2024-06-06 오후 10 10 15" src="https://github.com/24AWP-FAVICON/frontend/assets/101111603/d2f6f2b2-c6ce-42e8-812b-3da14d31c70a">
